### PR TITLE
Refactor reading from config file

### DIFF
--- a/dapgw2email/usr/local/bin/dapgw2email.py
+++ b/dapgw2email/usr/local/bin/dapgw2email.py
@@ -40,34 +40,36 @@ if not os.path.isfile(conffile):
    ErrExit()
 
 config = configparser.ConfigParser()
+config.read(conffile)
 
-try:
-   config.read(conffile)
-except:
+# check whether config file has correct section, this will fail if the configfile does not exist at the specified path
+if not config.has_section('dapgw2email'):
    log.error("Check " + conffile + " for proper [dapgw2email] section heading")
    ErrExit()
 
+# the following try/except blocks check for required options in the config file, logging an error message and exiting
+# if the option is not found.
 try:
    ric = config.get('dapgw2email', 'RIC').encode('utf-8')
-except:
+except configparser.NoOptionError:
    log.error("Check " + conffile + " for proper RIC value in [dapgw2email] section")
    ErrExit()
 
 try:
    smtp = config.get('dapgw2email', 'SMTP')
-except:
+except configparser.NoOptionError:
    log.error("Check " + conffile + " for proper SMTP value in [dapgw2email] section")
    ErrExit() 
 
 try:
    sender = config.get('dapgw2email', 'SENDER')
-except:
+except configparser.NoOptionError:
    log.error("Check " + conffile + " for proper SENDER value in [dapgw2email] section")
    ErrExit() 
 
 try:
    recipient = config.get('dapgw2email', 'RECIPIENT')
-except:
+except configparser.NoOptionError:
    log.error("Check " + conffile + " for proper RECIPIENT value in [dapgw2email] section")
    ErrExit() 
 
@@ -79,7 +81,7 @@ for r in rubrics:
    try:
       rubric_value = config.get('dapgw2email', r).encode('utf-8')
       rlist.append(rubric_value)
-   except:
+   except configparser.NoOptionError:
       pass
 
 

--- a/dapgw2email/usr/local/bin/dapgw2email.py
+++ b/dapgw2email/usr/local/bin/dapgw2email.py
@@ -71,71 +71,17 @@ except:
    log.error("Check " + conffile + " for proper RECIPIENT value in [dapgw2email] section")
    ErrExit() 
 
-try:
-   r1 = config.get('dapgw2email', 'R1').encode('utf-8')
-except:
-   pass
+rubrics = ['R'+str(i) for i in range(1, 10)]  # create list containing names of optional rubrics r1-r9
+rlist = [ric]  # initialize list of rubric values with RIC as first item
 
-try:
-   r2 = config.get('dapgw2email', 'R2').encode('utf-8')
-except:
-   pass
+# loop through dict of optional rubric names and add the rubric value to rlist if it exists in the config file
+for r in rubrics:
+   try:
+      rubric_value = config.get('dapgw2email', r).encode('utf-8')
+      rlist.append(rubric_value)
+   except:
+      pass
 
-try:
-   r3 = config.get('dapgw2email', 'R3').encode('utf-8')
-except:
-   pass
-
-try:
-   r4 = config.get('dapgw2email', 'R4').encode('utf-8')
-except:
-   pass
-
-try:
-   r5 = config.get('dapgw2email', 'R5').encode('utf-8')
-except:
-   pass
-
-try:
-   r6 = config.get('dapgw2email', 'R6').encode('utf-8')
-except:
-   pass
-
-try:
-   r7 = config.get('dapgw2email', 'R7').encode('utf-8')
-except:
-   pass
-
-try:
-   r8 = config.get('dapgw2email', 'R8').encode('utf-8')
-except:
-   pass
-
-try:
-   r9 = config.get('dapgw2email', 'R9').encode('utf-8')
-except:
-   pass
-
-rlist = []
-rlist.append(ric)
-if 'r1' in locals():
-   rlist.append(r1)
-if 'r2' in locals():
-   rlist.append(r2) 
-if 'r3' in locals():
-   rlist.append(r3) 
-if 'r4' in locals():
-   rlist.append(r4)
-if 'r5' in locals():
-   rlist.append(r5)
-if 'r6' in locals():
-   rlist.append(r6)
-if 'r7' in locals():
-   rlist.append(r7)
-if 'r8' in locals():
-   rlist.append(r8)
-if 'r9' in locals():
-   rlist.append(r9) 
 
 myFrom    = "From: Pi-Star <" + sender + ">\n"
 myTo      = "To: " + recipient + "\n"


### PR DESCRIPTION
I refactored the code for reading rubrics from the config file to make the code much more concise. 

Additionally, I changed the try/except blocks used when reading options from the config file to explicitly catch configparser errors rather than all exceptions. See [PEP8](https://www.python.org/dev/peps/pep-0008/#programming-recommendations) for rationale.

Let me know what you think. 73 KJ7GES